### PR TITLE
Add Pokémon info endpoint backed by PokeAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # ci_education
+
+A simple Gin-based API server used for educational purposes.
+
+## Endpoints
+
+- `GET /health` returns `ok`.
+- `GET /hello?name=NAME` returns a greeting.
+- `GET /pokemon/:name` fetches data from the [PokeAPI](https://pokeapi.co)
+  and returns basic information about the given Pokémon.
+

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 
@@ -21,6 +23,37 @@ func setupRouter() *gin.Engine {
 			name = "world"
 		}
 		c.JSON(http.StatusOK, gin.H{"message": "hello " + name})
+	})
+
+	r.GET("/pokemon/:name", func(c *gin.Context) {
+		name := c.Param("name")
+		baseURL := getenv("POKEAPI_BASE_URL", "https://pokeapi.co/api/v2")
+		url := fmt.Sprintf("%s/pokemon/%s", baseURL, name)
+
+		resp, err := http.Get(url)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch Pokemon"})
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			c.JSON(resp.StatusCode, gin.H{"error": "pokemon not found"})
+			return
+		}
+
+		var data struct {
+			Name           string `json:"name"`
+			Height         int    `json:"height"`
+			Weight         int    `json:"weight"`
+			BaseExperience int    `json:"base_experience"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to parse response"})
+			return
+		}
+
+		c.JSON(http.StatusOK, data)
 	})
 
 	return r

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -18,5 +21,38 @@ func TestHealth(t *testing.T) {
 	}
 	if body := w.Body.String(); body != "ok" {
 		t.Fatalf("expected body 'ok', got %q", body)
+	}
+}
+
+func TestPokemon(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/pokemon/pikachu" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"name":"pikachu","height":4,"weight":60,"base_experience":112}`)
+	}))
+	defer ts.Close()
+
+	os.Setenv("POKEAPI_BASE_URL", ts.URL)
+	defer os.Unsetenv("POKEAPI_BASE_URL")
+
+	r := setupRouter()
+	req := httptest.NewRequest(http.MethodGet, "/pokemon/pikachu", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var data struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &data); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if data.Name != "pikachu" {
+		t.Fatalf("expected name pikachu, got %s", data.Name)
 	}
 }


### PR DESCRIPTION
## Summary
- add `/pokemon/:name` endpoint that queries the external PokeAPI and returns basic data
- document new endpoint
- test Pokémon handler using a mocked PokeAPI server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b909d3c760832e95b9d281ee7c2dfd